### PR TITLE
Updated with CFP extension

### DIFF
--- a/2017-melbourne/cfp.md
+++ b/2017-melbourne/cfp.md
@@ -28,6 +28,7 @@ TODO:
       <div class="col-lg-10 col-md-10 col-sm-10">
 
         <h1>Call for Presentations 2017</h1>
+        <h2>Now EXTENDED to Monday 10th July</h2>
         <br />
 
         <p>
@@ -81,7 +82,7 @@ TODO:
         <ul>
           <li>CFP Launch Party - 15th May</li>
           <li>CFP Opens - 15th May</li>
-          <li>CFP Closes - June 30th</li>
+          <li>CFP Closes - EXTENDED - 10th July</li>
           <li>Notify Presenters - July 15th</li>
           <li>Conference Day 1: Presentations - Monday, 28-Aug-2017</li>
           <li>Conference Day 2: Unconference - Tuesday, 29-Aug-2017</li>

--- a/index.html
+++ b/index.html
@@ -59,11 +59,10 @@ redirect_from:
 							<p style="margin-bottom:0;"> <!-- for some reason we need to remove the margin here... -->
 								<i class="fa fa-ticket fa-2x"></i>
 								<br />
-								<a href="https://www.eventbrite.com/e/compose-melbourne-2017-cfp-party-tickets-34185207877"
-								   class="landing-link">
-									<br /> Register for 2017
-                                    <br /> Call for Presentations
-									<br /> Launch Party
+                <a href="http://www.composeconference.org/2017-melbourne/cfp/"
+                   class="landing-link">
+                  <br /> Call for Presentations
+                  <br /> Now EXTENDED to Monday 10th July!
 								</a>
 							</p>
 						</div>


### PR DESCRIPTION
- Removed out of date "CFP Launch Party" link from the front page
- Replaced with "CFP EXTENDED" link
- Edited CFP page with prominent CFP extension info, new dates