### PR TITLE
Added first cut of the 2018 CFP page

### DIFF
--- a/2018-melbourne/cfp.md
+++ b/2018-melbourne/cfp.md
@@ -259,8 +259,6 @@ TODO:
       <div class="col-lg-10 col-md-10 col-sm-10">
         <p> The second day will be dedicated to workshops and <a href="https://en.wikipedia.org/wiki/Unconference">unconferences</a>. </p>
         <h3> Workshops </h3>
-        <p> We will be running a beginners Haskell workshop. </p>
-        <p>
           If you wish to run a workshop on the second day of the conference, then
           please let us know. Alternatively, if there is a workshop that would interest
           you as an attendee, then please also let us know.

--- a/2018-melbourne/cfp.md
+++ b/2018-melbourne/cfp.md
@@ -1,0 +1,299 @@
+---
+layout: 2018-melbourne/melbourne
+title: Call for Proposals
+---
+
+<!--
+
+TODO:
+
+* Footer
+* Dates
+
+-->
+
+
+<div class="sep talk melbourne" data-stellar-background-ratio="0.5" style="background-position: 50% -91.5px;"></div>
+
+<br />
+<div class="container">
+  <div class="row">
+    <div class="col-lg-4 col-md-4 col-sm-4 name">
+
+      {% include 2017-melbourne/languages.html %}
+
+    </div>
+
+    <div class="col-lg-8 col-md-8 col-sm-8 name-desc">
+      <div class="col-lg-10 col-md-10 col-sm-10">
+
+        <h1>Call for Presentations 2018 </h1>
+        <br />
+
+        <p>
+          Compose :: Melbourne is a functional programming conference focused on
+          developing the community and bringing functional programming to a wider
+          audience. It is a 2-day event being held in Melbourne, Australia on the
+          27th and 28th of August 2018. The first day features a single track of
+          presentations followed by a second day of workshops and an unconference.
+          We are a sister-conference of the NY based Compose :: Conference.
+        </p>
+
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="container cfpsection" id="knowmore">
+  <div class="row">
+    <div class="col-lg-4 col-md-4 col-sm-4 name">
+      <h2>Would you like to know more?</h2>
+    </div>
+
+    <div class="col-lg-8 col-md-8 col-sm-8 name-desc">
+      <div class="col-lg-10 col-md-10 col-sm-10">
+        <p>
+          For news and announcements, or to just get in touch, please join the
+          <a href="http://groups.google.com/group/composemel">mailing list</a>.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="container cfpsection" id="dates">
+  <div class="row">
+    <div class="col-lg-4 col-md-4 col-sm-4 name">
+      <h2> Important Dates </h2>
+    </div>
+
+    <div class="col-lg-8 col-md-8 col-sm-8 name-desc">
+      <div class="col-lg-10 col-md-10 col-sm-10">
+        <ul>
+          <li>CFP Launch Party - Friday 11th May</li>
+          <li>CFP Opens - Friday 11th May</li>
+          <li>CFP Closes Sunday 1st July</li>
+          <li>Notify Presenters - Sunday 15th July</li>
+          <li>Conference Day 1: Presentations - Monday, 27-Aug-2018</li>
+          <li>Conference Day 2: Unconference & workshops - Tuesday, 28-Aug-2018</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="container cfpsection" id="submission">
+  <div class="row">
+    <div class="col-lg-4 col-md-4 col-sm-4 name">
+      <h2> Talk and Workshop Submission </h2>
+    </div>
+    <div class="col-lg-8 col-md-8 col-sm-8 name-desc">
+      <div class="col-lg-10 col-md-10 col-sm-10">
+       
+      Coming soon!
+      <!--
+        <p>
+          Submit a Presentation Proposal via
+          <a href="https://easychair.org/conferences/?conf=cmc20170">
+            Easy Chair</a>.
+        </p>
+        <p>
+          Or... <a href="mailto:composemel-admin@googlegroups.com">contact us via email</a>
+          with your proposed presentation at <code>composemel-admin@googlegroups.com</code>.
+        </p>
+        --> 
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="container cfpsection" id="guidelines">
+  <div class="row">
+    <div class="col-lg-4 col-md-4 col-sm-4 name">
+      <h2> Submission Guidelines </h2>
+    </div>
+    <div class="col-lg-8 col-md-8 col-sm-8 name-desc">
+      <div class="col-lg-10 col-md-10 col-sm-10">
+        <p>Talk slots will be 30 minutes: 25 minute talk and 5 minutes for questions.
+        </p>
+        <p> 
+          Provide sufficient detail in your submission to enable the reviewers
+          to understand your proposal and clearly identify what an attendee
+          will gain from attending your session. You should include the
+          following information in the submission system:
+        </p>
+        <ul>
+          <li> Authors - The details of each of the presenters </li>
+          <li> Title - Title of the presentation (please keep it brief and specific) </li>
+          <li>
+            Abstract	- A 300-500 word description of your presentation, ideally including...
+            <ul>
+              <li> Description of the content</li>
+              <li> Goal </li>
+            </ul>
+          </li>
+          <li>
+            Keywords - List any keywords that will help the program committee
+            and attendees categorise your presentation. Also indicate the
+            functional programming languages that you will be targeting.
+          </li>
+        </ul>
+        <p> You are not required to have a paper accompanying your presentation. </p>
+        <p>
+          Nothing upsets an audience more than a speaker that stands on stage blatantly
+          promoting his or her company, product or achievements.
+        </p>
+        <p>
+          Please keep the content of your talk on-topic and do not use this speaking
+          opportunity as a sales pitch.
+        </p>
+        <p>
+          <strong>Note: Accepted presenters will not be required to purchase a ticket.</strong>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="container cfpsection" >
+  <div class="row">
+    <div class="col-lg-4 col-md-4 col-sm-4 name">
+      <h2> Feel </h2>
+    </div>
+    <div class="col-lg-8 col-md-8 col-sm-8 name-desc">
+      <div class="col-lg-10 col-md-10 col-sm-10">
+        <p>
+          We want Compose :: Melbourne to be all about the community. We're aiming to
+          help foster the growth of functional programming in Melbourne and
+          unite all interested parties to spark a unified presence and a feeling
+          of camaraderie amongst FP and theory proponents in this wonderful
+          city!
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="container cfpsection" >
+  <div class="row">
+    <div class="col-lg-4 col-md-4 col-sm-4 name">
+      <h2> Audience </h2>
+    </div>
+    <div class="col-lg-8 col-md-8 col-sm-8 name-desc">
+      <div class="col-lg-10 col-md-10 col-sm-10">
+        <p>
+          Functional programming and programming language theory professionals
+          and enthusiasts. Newcomers, experts, anyone from other disciplines of
+          fields who is interested in what FP is or how it could help them with
+          their work, or simply make life more enjoyable!
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="container cfpsection" >
+  <div class="row">
+    <div class="col-lg-4 col-md-4 col-sm-4 name">
+      <h2> Diversity </h2>
+    </div>
+    <div class="col-lg-8 col-md-8 col-sm-8 name-desc">
+      <div class="col-lg-10 col-md-10 col-sm-10">
+        <p>
+          Soliciting a diverse range of speakers is important to us - anything you can do to distribute
+          information about this CFP and encourage submissions from under-represented
+          groups would be greatly appreciated.
+
+          We welcome *all* (new and established) contributions and encourage you to apply!
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="container cfpsection" >
+  <div class="row">
+    <div class="col-lg-4 col-md-4 col-sm-4 name">
+      <h2> Day One </h2>
+    </div>
+    <div class="col-lg-8 col-md-8 col-sm-8 name-desc">
+      <div class="col-lg-10 col-md-10 col-sm-10">
+        <p>
+          All topics for proposals for presentations are invited, but not limited to
+          explore the following topics:
+        </p>
+        <h3> New Languages </h3>
+        <p>
+          The development of new and emerging Functional Languages, and the toolsets
+          around them.
+        </p>
+        <h3> Libraries and Tools </h3>
+        <p>
+          Exploring the use and development of new and underrepresented tools and
+          libraries.
+        </p>
+        <h3> Production Systems </h3>
+        <p>
+          2018 continues the trend of many previously under-deployed languages
+          and systems break through into production. We're looking for
+          war-stories, success-stories and sob-stories!
+        </p>
+        <h3> Theory </h3>
+        <p>
+          Theory is the cutting edge of new functional programming. Show the world
+          what is rising over the horizon.
+        </p>
+        <h3> Art and Music </h3>
+        <p> Exciting and innovative usage of functional programming language in the arts! </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="container cfpsection" >
+  <div class="row">
+    <div class="col-lg-4 col-md-4 col-sm-4 name">
+      <h2> Day Two </h2>
+    </div>
+    <div class="col-lg-8 col-md-8 col-sm-8 name-desc">
+      <div class="col-lg-10 col-md-10 col-sm-10">
+        <p> The second day will be dedicated to workshops and <a href="https://en.wikipedia.org/wiki/Unconference">unconferences</a>. </p>
+        <h3> Workshops </h3>
+        <p> We will be running a beginners Haskell workshop. </p>
+        <p>
+          If you wish to run a workshop on the second day of the conference, then
+          please let us know. Alternatively, if there is a workshop that would interest
+          you as an attendee, then please also let us know.
+        </p>
+        <h3> Unconference </h3>
+        <p>
+          Got something random you want to talk about? The unconference will run
+          the second day. There will be a whiteboard with spaces where anyone
+          can write their name down to speak. There's no need to bring anything
+          but yourself and your ideas and speaking voice.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="container cfpsection" >
+  <div class="row">
+    <div class="col-lg-4 col-md-4 col-sm-4 name">
+      <h2> Sponsors </h2>
+    </div>
+    <div class="col-lg-8 col-md-8 col-sm-8 name-desc">
+      <div class="col-lg-10 col-md-10 col-sm-10">
+        <p>
+          We are seeking sponsors to support us in putting on this conference. If
+          you or your company would like to sponsor us, please get in contact via
+          <a href="mailto:composemel-admin@googlegroups.com">composemel-admin@googlegroups.com</a>.
+        </p>
+        <p>
+          You can find our prospectus
+          <a href="../sponsorship-prospectus/">here.</a>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/2018-melbourne/sponsorship-prospectus.md
+++ b/2018-melbourne/sponsorship-prospectus.md
@@ -1,5 +1,5 @@
 ---
-layout: 2017-melbourne/melbourne
+layout: 2018-melbourne/melbourne
 title: "C&#9702;mp&#9702;se :: Melbourne - 2018 Sponsorship-Prospectus"
 ---
 

--- a/_includes/2018-melbourne/header.html
+++ b/_includes/2018-melbourne/header.html
@@ -9,6 +9,7 @@
     </div>
     <div class="col-lg-6 col-md-6 col-sm-8 col-xs-1">
       <ul class="sections nav nav-pills nav-justified">
+        <li class="hidden-xs"><a href="/2018-melbourne/cfp/" class="smoothScroll">CFP</a></li>
         <li class="hidden-xs"><a href="/2018-melbourne/sponsorship-prospectus/">Melbourne 2018 Sponsorship Prospectus</a></li>
         <li class="hidden-xs"><a href="/conduct/" class="smoothScroll">Policies</a></li>
 


### PR DESCRIPTION
Still missing actual EasyChair link, pending setup. Updated some of the language, put in this year's timeline.