### PR TITLE
Add missing CFP link for small devices

### DIFF
--- a/2018-melbourne/cfp.md
+++ b/2018-melbourne/cfp.md
@@ -20,7 +20,7 @@ TODO:
 <br />
 <div class="container">
   <div class="row">
-    <div class="col-lg-4 col-md-4 col-sm-4 name">
+    <div class="col-lg-4 col-md-4 col-sm-4 name hidden-xs hidden-sm">
 
       {% include 2018-melbourne/languages.html %}
 
@@ -97,7 +97,7 @@ TODO:
     </div>
     <div class="col-lg-8 col-md-8 col-sm-8 name-desc">
       <div class="col-lg-10 col-md-10 col-sm-10">
-       
+
         <p>
           Submit a Presentation Proposal or Workshop via
           <a href="https://compose-cfparty-2018.herokuapp.com/submissions/new">
@@ -121,7 +121,7 @@ TODO:
       <div class="col-lg-10 col-md-10 col-sm-10">
         <p>Talk slots will be 30 minutes: 25 minute talk and 5 minutes for questions.
         </p>
-        <p> 
+        <p>
           Provide sufficient detail in your submission to enable the reviewers
           to understand your proposal and clearly identify what an attendee
           will gain from attending your session. You should include the

--- a/2018-melbourne/sponsors.md
+++ b/2018-melbourne/sponsors.md
@@ -27,7 +27,7 @@ title: "C&#9702;mp&#9702;se :: Melbourne - 2018 Sponsors"
       </p>
       <p>
         To find out how to be a sponsor, please take a look at our
-        <a href="../sponsorship-prospectus/">sponsorship information</a>.
+        <a href="/2018-melbourne/sponsorship-prospectus/">sponsorship information</a>.
       </p>
       <!-- <h3> More details coming soon... </h3> -->
     </div>

--- a/_includes/2018-melbourne/header.html
+++ b/_includes/2018-melbourne/header.html
@@ -21,6 +21,7 @@
               <h1 class="logo"><a href="/">C&#9702;mp&#9702;se</a></h1>
               <i class="fa fa-times menu-close"></i>
 
+              <a href="/2018-melbourne/cfp/" class="smoothScroll">CFP</a>
               <a href="/2018-melbourne/sponsors/">Sponsors</a>
               <a href="/2018-melbourne/sponsorship-prospectus/">Melbourne 2018 Sponsorship Prospectus</a>
               <a href="/conduct/" class="smoothScroll">Policies</a>


### PR DESCRIPTION
Also:
- Hidden the language icons on small devices because they push the heading and text under the fold
- Made the sponsorship prospectus link relative to the domain